### PR TITLE
feat: post to concrete date

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ program.command("edit").alias("e").description("Edits log item").action(edit);
 program.command("post")
     .description("Posts log to jira server")
     .option('-y', 'yesterday')
+    .option('-d, --date <year>-<month>-<day>/<month>-<day>/<day>', 'offset in past (in days)')
     .option('-o, --offset <int>', 'offset in past (in days)')
     .action(post);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jiralog",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jiralog",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jiralog",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "CLI tool for posting work log to Jira server",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -117,7 +117,20 @@ Posts all records for today to provided jira server.
 Posts work log for yesterday
 `jira post -y`
 
-#### --offset < int >
+#### -d < date > / --date < date >
+Posts work log for the concrete date. 
+> Different input types are possible
+> - only day of the month
+> - day + month
+> - day + month + year
+
+`jira post -d 10` (With post work log to the 10th day of the current month and year)
+
+`jira post -d 5-2` (With post work log to the second of May of the current year)
+
+`jira post -d 2020-5-2` (With post work log to the second of May 2020)
+
+#### -o < int > / --offset < int >
 Posts work log to the server with a specified offset in days
 
 `jira post --offset 2` (Will post the current work log for the day before yesterday)

--- a/readme.md
+++ b/readme.md
@@ -121,8 +121,14 @@ Posts work log for yesterday
 Posts work log for the concrete date. 
 > Different input types are possible
 > - only day of the month
-> - day + month
-> - day + month + year
+> - month + day
+> - year + month + day
+
+Date is expected in one of following formats:
+
+- `day`
+- `month-day`
+- `year-month-day`
 
 `jira post -d 10` (With post work log to the 10th day of the current month and year)
 

--- a/utils/post.js
+++ b/utils/post.js
@@ -78,6 +78,55 @@ function getDayAt(hours, daysOffset) {
   return day;
 }
 
+function getConfirmationMessage (daysOffset, concreteDate) {
+  const question = 'are you sure you want to post this to jira server for {!0!}?'
+  const compose = (option) =>{
+    return question.replace("{!0!}", option);
+  }
+
+  if(concreteDate && daysOffset === undefined){
+    return compose(concreteDate.toISOString().slice(0, 10));
+  }
+
+  let confirmMessage;
+
+  switch (daysOffset){
+    case 0:
+      confirmMessage = compose('today')
+      break;
+    case 1:
+      confirmMessage = compose('yesterday')
+      break;
+    default:
+      confirmMessage = compose(`${daysOffset} days back`);
+  }
+
+  return confirmMessage;
+}
+
+function getTargetDate(input){
+  const members = input.split('-');
+
+  const date = new Date();
+
+  if(members.length === 1){
+    date.setDate(members[0])
+  }
+
+  if(members.length === 2){
+    date.setMonth(members[0]-1)
+    date.setDate(members[1])
+  }
+
+  if(members.length === 3){
+    date.setFullYear(members[0], members[1] - 1, members[2])
+  }
+
+  return date;
+}
+
 module.exports.postWorklog = postWorklog;
 module.exports.getTodayAt = getTodayAt;
 module.exports.getDayAt = getDayAt;
+module.exports.getConfirmationMessage = getConfirmationMessage;
+module.exports.getTargetDate = getTargetDate;


### PR DESCRIPTION
# Reason for changes
Based on feedback it's required to be able to provide not offset but the concrete target date

# Changes
`-d` option was added to the `post` command. User can provide `day`, `month-day`, `year-month-day`

# What can be improved
It's needed to be able to provide time.