### PR TITLE
feat: custom format

### DIFF
--- a/commands/format.js
+++ b/commands/format.js
@@ -1,0 +1,76 @@
+const { readOrCreate, resetFormats, formatWorkLogRecord, formatGitActivityDescription, updateFormats} = require("../utils/format");
+const {askForConfirmation} = require("../utils/askFor");
+
+async function format(options) {
+    const formats = readOrCreate();
+    
+    if(Object.keys(options).length === 0){
+        console.log(`defined formats are listed below. Use 
+            'jira format --check' to check them, 
+            'jira format --default' to reset formats,
+            'jira format --edit' to edit existing formats`);
+        console.log(` - format for regular work log : ${formats.workLogRecord}`)
+        console.log(` - format for git activity when no reference found in commit message : ${formats.gitActivityDesctiptionNoReference}`)
+        console.log(` - format for git activity when there is a reference in commit message : ${formats.gitActivityDesctiptionWhenReferenceFound}`)
+    }
+    
+    if(options.default){
+        await resetToDefault();
+    } 
+
+    if(options.check){
+        check();
+    }
+    
+    if(options.edit){
+        await updateFormats();
+    }
+
+}
+
+function check() {
+    console.log('current formats will be applied like this:\n');
+    const item = {
+        hours: 0.5,
+        activity: 'I took part in daily meeting'
+    };
+    console.log(`if you have a logged activity with description ${item.activity} with ${item.hours} hours duration it will be added in daily log in the following format:`)
+    console.log(formatWorkLogRecord(item))
+
+
+    const gitActivityWithReference = {
+        tickets: ['12A-1'],
+        repo: 'App.Messaging.Service',
+    }
+    console.log(`if you create a worklog record based on commit in the following format:
+        feat: support of service bus
+        
+        added support of azure service bus via mass transit to send messages
+        
+        refs: #${gitActivityWithReference.tickets[0]}
+        in the ${gitActivityWithReference.repo} repository you will get the following text as a default text:`)
+
+    console.log(formatGitActivityDescription(gitActivityWithReference));
+
+    const gitActivityWithNoReference = {
+        repo: 'App.Logging.Service',
+    }
+    console.log(`if you create a worklog record based on commit in the following format:
+        fix: logs handling
+        
+        in the ${gitActivityWithNoReference.repo} repository you will get the following text as a default text:`)
+
+    console.log(formatGitActivityDescription(gitActivityWithNoReference));
+}
+
+async function resetToDefault() {
+    const confirmation = await askForConfirmation('are you sure you want to reset formats to default state?');
+    if (confirmation) {
+        resetFormats();
+    }
+    return;
+}
+
+module.exports = {
+    format,
+}

--- a/commands/git.js
+++ b/commands/git.js
@@ -5,6 +5,7 @@ const log = require("./log");
 const { exists, read, configFile } = require("../utils/file");
 const { writeConfigIsMissing } = require("../utils/loggers");
 const { getTargetDate } = require("../utils/post");
+const { formatGitActivityDescription } = require("../utils/format");
 
 function git(options = {}) {
     const config = getConfig();
@@ -59,10 +60,7 @@ function getLabelForContribution(contribution){
 }
 
 function getRecord(contribution){
-    if(contribution.tickets){
-        return `Worked on task #${contribution.tickets[0]} in ${contribution.repo} repository.`;
-    }
-    return `worked with ${contribution.repo} repository.`;
+    return formatGitActivityDescription(contribution);
 }
 
 function listRepos(reposDirectory){ 

--- a/commands/post.js
+++ b/commands/post.js
@@ -1,7 +1,8 @@
-const { askForConfirmation, askForSecret} = require("../utils/askFor");
+const { askForConfirmation } = require("../utils/askFor");
 const { exists, configFile, read, todayFile } = require("../utils/file");
 const { postWorklog, getDayAt, getTodayAt, getConfirmationMessage, getTargetDate} = require("../utils/post");
 const { countTotalHours } = require("../utils/workLog");
+const { formatWorkLogRecord } = require("../utils/format");
 const { getKey, decryptKey } = require("../utils/configBuilder");
 
 const logFile = todayFile();

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const { yesterday } = require("./commands/yesterday");
 const { jCommand } = require("./commands/jCommand");
 const { template } = require("./commands/template");
 const { git } = require("./commands/git");
+const { format } = require("./commands/format");
 
 program.command("config").description("Configures tool").action(config);
 program
@@ -60,5 +61,12 @@ program.command("git")
     .option('-r, --repos', 'lists all tracked repositories')
     .option('-d, --date <date>', 'date to get contributions')
     .action(git)
+
+program.command('format')
+    .description('manages formats of logging')
+    .option('-c, --check', 'checks provided formats')
+    .option('-d, --default', 'resets formats to default values')
+    .option('-e, --edit', 'edits formats')
+    .action(format)
 
 program.parse();

--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,35 @@ Posts work log to the server with a specified offset in days
 
 `jira post --offset 2` (Will post the current work log for the day before yesterday)
 
+### format
+Allows user to define which formats are used to create work log records.
+
+#### [no flag]
+Lists available formats
+
+#### -c / --check
+Provides information about defined formats.
+
+`jira format -c`
+
+#### -d / --default
+Resets created formats to default ones
+
+`jira format -d`
+
+#### -e / --edit
+Allows user edit created formats.
+
+`jira format -d`
+
+> How formats must be defined
+> 
+> `jira format -d` will start wizard of formats editing. User should provide values for formats in the way, described in command hints.
+> 
+> For example, if format for work log record is being entered, you need to provide a text with some placeholders that later will be replaced with real values. In this case you need provide WORKLOG_DURATION where you want to get duration of activity and WORKLOG_DESCRIPTION where description is required to be inserted.
+
+In order to check entered scenarios use `jira format --check`. In case it's required to reset formats to default use `jira format --default`.
+
 ## Input date as a parameter
 
 > Different input types are possible

--- a/utils/file.js
+++ b/utils/file.js
@@ -55,6 +55,10 @@ function configFile() {
   return path.join(getDirectory(), "config.jira");
 }
 
+function formatsFile() {
+  return path.join(getDirectory(), "formats.jira");
+}
+
 function templatesFile() {
   return path.join(getDirectory(), "templates.jira");
 }
@@ -74,4 +78,6 @@ module.exports.remove = remove;
 module.exports.todayFile = todayFile;
 module.exports.yesterdayFile = yesterdayFile;
 module.exports.configFile = configFile;
+module.exports.configFile = configFile;
+module.exports.formatsFile = formatsFile;
 module.exports.templatesFile = templatesFile;

--- a/utils/format.js
+++ b/utils/format.js
@@ -1,0 +1,84 @@
+const {formatsFile, exists, write, read} = require("./file");
+const { askForParameterWithDefault } = require("./askFor");
+
+const placeholders = {
+    workLogDuration: 'WORKLOG_DURATION',
+    workLogDescription: 'WORKLOG_DESCRIPTION',
+    taskNumber: 'TASK_NUMBER',
+    repositoryName: 'REPOSITORY_NAME',
+}
+
+const defaultFormats = {
+    workLogRecord: `- (${placeholders.workLogDuration}h) ${placeholders.workLogDescription}`,
+    gitActivityDesctiptionWhenReferenceFound: `Worked on task #${placeholders.taskNumber} in ${placeholders.repositoryName} repository`,
+    gitActivityDesctiptionNoReference: `Worked with ${placeholders.repositoryName} repository`,
+}
+
+const file = formatsFile();
+
+const formatWorkLogRecord = (item) => {
+    const formats = readOrCreate();
+    const recordFormat = formats.workLogRecord;
+    return `${recordFormat.replace(placeholders.workLogDuration, item.hours).replace(placeholders.workLogDescription, item.activity)}`;
+}
+
+const formatGitActivityDescription = (contribution) => {
+    const formats = readOrCreate();
+
+    if(contribution.tickets){
+        const format = formats.gitActivityDesctiptionWhenReferenceFound;
+        return format.replace(placeholders.taskNumber, contribution.tickets.join(', ')).replace(placeholders.repositoryName, contribution.repo);
+    }
+    const format = formats.gitActivityDesctiptionNoReference;
+    return format.replace(placeholders.repositoryName, contribution.repo);
+    
+}
+
+const readOrCreate = () =>{
+    const configExists = exists(file);
+
+    if(!configExists){
+        write(file, defaultFormats);
+        return defaultFormats;
+    }
+    
+    const formats = read(file);
+    
+    return {
+        ...defaultFormats,
+        ...formats,
+    }
+}
+
+const resetFormats = () => {
+    write(file, defaultFormats);
+}
+
+const updateFormats = async () => {
+    const formats = read(file);
+
+    const workLogRecord = await askForParameterWithDefault(`enter format for regular worklog. 
+    Use ${placeholders.workLogDuration} for duration and ${placeholders.workLogDescription} for description`, formats.workLogRecord);
+    
+    const gitActivityDesctiptionNoReference = await askForParameterWithDefault(`enter format for git activity with no reference found. 
+    Use ${placeholders.repositoryName} for repository name`, formats.gitActivityDesctiptionNoReference);
+
+
+    const gitActivityDesctiptionWhenReferenceFound = await askForParameterWithDefault(`enter format for git activity when there is a reference found. 
+    Use ${placeholders.repositoryName} for repository name and ${placeholders.taskNumber} for task number`, formats.gitActivityDesctiptionWhenReferenceFound);
+    
+    write(file, {
+        workLogRecord,
+        gitActivityDesctiptionWhenReferenceFound,
+        gitActivityDesctiptionNoReference,
+    })
+}
+
+module.exports = {
+    defaultFormats,
+    formatWorkLogRecord,
+    formatGitActivityDescription,
+    readOrCreate,
+    resetFormats,
+    updateFormats,
+}

--- a/utils/loggers.js
+++ b/utils/loggers.js
@@ -1,9 +1,10 @@
 const {countTotalHours} = require("./workLog");
+const {formatWorkLogRecord} = require("./format");
 
 function writeDay(data) {
   let total = 0;
   data.forEach((element) => {
-    console.log(`(${element.hours}h) ${element.activity}`);
+    console.log(`${formatWorkLogRecord(element)}`);
     total += +element.hours;
   });
   console.log(`${total}h TOTAL`);


### PR DESCRIPTION
# Reason for changes
According to user's feedback it's required to have opportunity to change the default format of creating worklogs.

# Changes
- custom worklogs can be defined
- `jira format` command was introduced
- required adjustments in readme were added
